### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -29,7 +29,7 @@ function fish_prompt
   if git_is_repo
     # Displaying the path we're at using short path by default.
     # Particular treatment in case of browsing a Git repository.
-    set root_folder (command git rev-parse --show-toplevel ^/dev/null)
+    set root_folder (command git rev-parse --show-toplevel 2>/dev/null)
     set parent_root_folder (dirname $root_folder)
     set cwd (echo $PWD | sed -e "s|$parent_root_folder/||")
     echo -n -s $color_blue "("$color_dim $cwd $color_blue")" $color_off " "


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
